### PR TITLE
Fix omxplayer is not visible under the Qt application

### DIFF
--- a/BkgVideoPOTVL.qml
+++ b/BkgVideoPOTVL.qml
@@ -26,6 +26,7 @@ import PiOmxTexturesVideoLayer 0.1
 Rectangle {
     anchors.fill: parent
     color: "orange"
+    opacity: 0.2
 
     Video {
         id: player


### PR DESCRIPTION
The rectangle defined inside BkgVideoPOTVL.qml was missing the opacity property.